### PR TITLE
config set: test setting with null & not-defined parent

### DIFF
--- a/test/sharness/t0021-config.sh
+++ b/test/sharness/t0021-config.sh
@@ -57,6 +57,9 @@ test_config_cmd() {
   test_config_cmd_set "--json" "beep3" "true"
   test_config_cmd_set "--json" "beep3" "false"
   test_config_cmd_set "--json" "Discovery" "$CONFIG_SET_JSON_TEST"
+  test_config_cmd_set "--json" "deep-not-defined.prop" "true"
+  test_config_cmd_set "--json" "deep-null" "null"
+  test_config_cmd_set "--json" "deep-null.prop" "true"
 
 }
 


### PR DESCRIPTION
This adds a failing for the case described in #1561 to #1570
